### PR TITLE
ログインしていない場合はログインページに遷移させる

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  before_action :login_required
+
+  private
+
+  def login_required
+    redirect_to new_user_session_path unless current_user
+  end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -2,6 +2,7 @@
 
 class Users::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
+  skip_before_action :login_required
 
   # GET /resource/sign_in
   # def new


### PR DESCRIPTION
ログインしているユーザーの家計簿を表示させるアプリなので、ログインしていない場合はログインしてもらうようログインページに遷移させる
※この処理がないとログインせずにアクセスできてしまい、エラー画面が表示されてしまう